### PR TITLE
resolves issue #2 

### DIFF
--- a/AdventureWorks.AppHost/Program.cs
+++ b/AdventureWorks.AppHost/Program.cs
@@ -1,5 +1,6 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddProject<Projects.Frontend>("frontend");
+builder.AddProject<Projects.Frontend>("frontend")
+       .WithExternalHttpEndpoints();
 
 builder.Build().Run();


### PR DESCRIPTION
resolves issue #2 - a published Aspire app lacking public http/s traffic visibility due to an unconfigured ingress port - by adding ingress using the `WithExternalHttpEndpoints` method in the App Host project